### PR TITLE
Fix boolean literal error

### DIFF
--- a/ios/RNGoogleIMAManager.m
+++ b/ios/RNGoogleIMAManager.m
@@ -25,7 +25,7 @@ RCT_EXPORT_MODULE();
 - (NSDictionary *)constantsToExport
 {
     return @{
-        @"googleIMA": YES,
+        @"googleIMA": @YES,
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-google-ima",
   "title": "React Native Google IMA",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "TODO",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Per Xcode (in `ted_app_react_native` context):

❌  ted_app_react_native/node_modules/react-native-google-ima/ios/RNGoogleIMAManager.m:28:23: boolean literal must be prefixed by '@' in a collection

It compiles properly after this change.